### PR TITLE
New config & env mechanism, some test fixes (#1)

### DIFF
--- a/code/tests/config.py
+++ b/code/tests/config.py
@@ -1,0 +1,26 @@
+import os
+import os.path
+
+
+class PATHS:
+    TESTS_DIR = os.path.normpath(os.path.dirname(__file__))
+
+
+class MQ:
+
+    # Queue manager connection setup
+    class QM:
+        NAME = os.environ.get('PYMQI_TEST_QM_NAME', 'QM01')
+        HOST = os.environ.get('PYMQI_TEST_QM_HOST', '127.0.0.1')
+        PORT = os.environ.get('PYMQI_TEST_QM_PORT', '31414')
+        CHANNEL = os.environ.get('PYMQI_TEST_QM_CHANNEL', 'SVRCONN.1')
+        USER = os.environ.get('PYMQI_TEST_QM_USER', 'myuser')
+        PASSWORD = os.environ.get('PYMQI_TEST_QM_PASSWORD', 'mypassword')
+
+    # Queue naming setup
+    class QUEUE:
+        PREFIX = os.environ.get('PYMQI_TEST_QUEUE_PREFIX', '')
+        QUEUE_NAMES = {
+            'TestRFH2PutGet': PREFIX + 'TEST.PYMQI.RFH2PUTGET',
+            }
+

--- a/code/tests/delete_mq_objects.py
+++ b/code/tests/delete_mq_objects.py
@@ -9,23 +9,19 @@ This script creates the MQ objects required for the test suite.
 import subprocess
 import sys
 import time
+import config
 
+print "Deleting all MQ Objects required to run the test.\n"
 
-mqsc_script = """
-DEFINE LISTENER(TEST.LISTENER) TRPTYPE(TCP) PORT(31414) CONTROL(QMGR) REPLACE
-START LISTENER(TEST.LISTENER)
-DEFINE QL(RFH2.TEST) REPLACE
-"""
-
-print "Creating all MQ Objects required to run the test.\n"
-
-print "Checking if Queue Manager QM01 exists.\n"
-dspmq_proc = subprocess.Popen(["dspmq", "-mQM01"], stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE)
+print "Checking if Queue Manager %s exists.\n" % config.MQ.QM.NAME
+dspmq_proc = subprocess.Popen(
+    ["dspmq", "-m%s" % config.MQ.QM.NAME], stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE)
 dspmq_output, dspmq_error = dspmq_proc.communicate()
 
 if dspmq_proc.returncode == 72:
-    print "Queue manager QM01 does not exist.  Nothing to do. Exiting.\n"
+    print ("Queue manager %s does not exist.  Nothing to do. Exiting.\n" %
+           config.MQ.QM.NAME)
     sys.exit(0)
 else:
     if dspmq_proc.returncode != 0:
@@ -37,8 +33,9 @@ else:
         sys.exit(1)
 
 print "Stopping Queue Manager.\n"
-endmqm_proc = subprocess.Popen(["endmqm", "QM01"], stdout=subprocess.PIPE,
-                               stderr=subprocess.PIPE)
+endmqm_proc = subprocess.Popen(
+    ["endmqm", config.MQ.QM.NAME], stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE)
 endmqm_output, endmqm_error = endmqm_proc.communicate()
 print endmqm_error
 start = time.time()
@@ -54,7 +51,7 @@ while not done:
     if disp_time <= 0:
         print dspmq_output
         current_disp = time.time()
-    dspmq_proc = subprocess.Popen(["dspmq", "-mQM01"],
+    dspmq_proc = subprocess.Popen(["dspmq", "-m%s" % config.MQ.QM.NAME],
                                   stdout=subprocess.PIPE,
                                   stderr=subprocess.PIPE)
     dspmq_output, dspmq_error = dspmq_proc.communicate()
@@ -73,12 +70,13 @@ print "Queue Manager Stopped.\n"
 
 
 time.sleep(5)
-dltmqm_proc = subprocess.Popen(["dltmqm", "QM01"], stdout=subprocess.PIPE,
+dltmqm_proc = subprocess.Popen(["dltmqm", config.MQ.QM.NAME],
+                               stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)
 dltmqm_output, dltmqm_error = dltmqm_proc.communicate()
 
 if dltmqm_proc.returncode != 0:
-    print "Error while deleting Queue Manager QM01."
+    print "Error while deleting Queue Manager %s." % config.MQ.QM.NAME
     print "-" * 80 + "\n"
     print dltmqm_error
     print "-" * 80 + "\n"

--- a/code/tests/env.py
+++ b/code/tests/env.py
@@ -1,0 +1,23 @@
+# test environment settings
+
+import sys
+import os
+
+
+def add_syspath(p):
+    """Add path p to sys.path without defeating PYTHONPATH.
+
+    Appends to sys.path if PYTHONPATH is set, otherwise put p at sys.path index
+    1.
+    """
+    if p not in sys.path:
+        if "PYTHONPATH" in os.environ:
+            sys.path.append(p)
+        else:
+            sys.path.insert(1, p)
+
+
+# Add pymqi code directory to sys.path for import from checkout
+# (needs in-place build of pymqe.so)
+add_syspath(os.path.normpath(os.path.join(os.path.dirname(__file__), '..')))
+

--- a/code/tests/test_h2py.py
+++ b/code/tests/test_h2py.py
@@ -7,7 +7,8 @@ import sys
 import inspect
 import unittest
 
-sys.path.insert(0, "..")
+# test env settings
+import env
 
 # PyMQI
 from pymqi import CMQC, CMQXC, CMQCFC
@@ -15,7 +16,8 @@ from pymqi import CMQC, CMQXC, CMQCFC
 ignore_dups = ["MQOD_CURRENT_LENGTH", "MQPMO_CURRENT_LENGTH", "MQRC_NONE",
                "MQACH_CURRENT_LENGTH", "MQCD_CURRENT_LENGTH", "MQCD_LENGTH_4",
                "MQCD_LENGTH_5", "MQCD_LENGTH_6", "MQCD_LENGTH_7", "MQCD_LENGTH_8",
-               "MQCD_LENGTH_9", "MQCFIF_STRUC_LENGTH", "MQCFGR_STRUC_LENGTH",
+               "MQCD_LENGTH_9", "MQCD_LENGTH_10", "MQCD_LENGTH_11",
+               "MQCFIF_STRUC_LENGTH", "MQCFGR_STRUC_LENGTH",
                "MQCFIN64_STRUC_LENGTH", "MQCFIN_STRUC_LENGTH", "MQACH_LENGTH_1"]
 
 class Testh2py(unittest.TestCase):

--- a/code/tests/test_mq80.py
+++ b/code/tests/test_mq80.py
@@ -1,6 +1,8 @@
 """ Tests for making sure MQ 8.0 features work properly.
 
-Require exporting the following environments variables pointing to an MQ 8.0 queue managers and credentials.
+Requires proper configuration in config.py or by setting the following
+environment variables (which the config module respects) pointing to an MQ 8.0
+queue managers and credentials.
 Substitute values as required.
 
 export PYMQI_TEST_QM_NAME=QM01
@@ -15,10 +17,8 @@ export PYMQI_TEST_QM_PASSWORD=mypassword
 import os
 import unittest
 
-# testfixtures
-from testfixtures import Replacer
-
-# test env
+# test config & env
+import config
 import env
 
 # PyMQI
@@ -28,6 +28,8 @@ from pymqi import CMQC, CMQXC, CMQCFC
 env_prefix = 'PYMQI_TEST_QM_'
 env_vars = ['NAME', 'HOST', 'PORT', 'CHANNEL', 'USER', 'PASSWORD']
 
+#TODO: Remove this? It's not used anymore, and invalid configuration should
+# lead to proper operation errors, anyway.
 def ensure_env_vars():
     missing = []
     for key in env_vars:
@@ -41,9 +43,8 @@ def ensure_env_vars():
 class TestMQ80(unittest.TestCase):
 
     def setUp(self):
-        ensure_env_vars()
         for key in env_vars:
-            setattr(self, key.lower(), os.environ[env_prefix + key])
+            setattr(self, key.lower(), getattr(config.MQ.QM, key))
 
     def get_conn(self):
         return pymqi.connect(self.name, self.channel, '{}({})'.format(self.host, self.port), self.user, self.password)

--- a/code/tests/test_mq80.py
+++ b/code/tests/test_mq80.py
@@ -12,12 +12,14 @@ export PYMQI_TEST_QM_PASSWORD=mypassword
 """
 
 # stdlib
-import inspect
 import os
 import unittest
 
 # testfixtures
 from testfixtures import Replacer
+
+# test env
+import env
 
 # PyMQI
 import pymqi

--- a/code/tests/test_rfh2.py
+++ b/code/tests/test_rfh2.py
@@ -5,8 +5,10 @@ Created on 15 Nov 2010
 '''
 
 import unittest
+import env
 import pymqi
 from pymqi import CMQC
+
 
 class TestRFH2(unittest.TestCase):
     """This test case tests the RFH2 class and it's methods.
@@ -248,7 +250,14 @@ class TestRFH2(unittest.TestCase):
         try:
             rfh2.add_folder("<a><b>c</a>")
         except pymqi.PYIFError, e:
-            self.assertEqual(str(e), "PYMQI Error: RFH2 - XML Folder not well formed. Exception: Opening and ending tag mismatch: b line 1 and a, line 1, column 12", "Not XML Folder not well formed on exception (add_folder)?." )
+            # Don't depend on the actual XML library getting used (lxml or
+            # minidom produce different error messages)
+            self.assertTrue(
+                str(e).startswith(
+                    "PYMQI Error: RFH2 - XML Folder not well formed. "
+                    "Exception:"),
+                    "Not 'XML Folder not well formed' exception (add_folder): "
+                    "%s" % (e, ))
 
     def test_encoding_on_pack_big_endian(self):
         """Test that pack() creates numeric fields with correct encoding. Big endian Test.

--- a/code/tests/test_rfh2_put_get.py
+++ b/code/tests/test_rfh2_put_get.py
@@ -5,6 +5,9 @@ Created on 15 Nov 2010
 '''
 
 import unittest
+import os.path
+import config
+import env
 import pymqi
 from pymqi import CMQC
 
@@ -13,39 +16,40 @@ class TestRFH2PutGet(unittest.TestCase):
     """This test case tests the RFH2 class and it's methods.
     """
 
+    messages_dir = os.path.join(os.path.dirname(__file__), "messages")
+
     def setUp(self):
         """ Create a new queue manager (TESTPMQI).
         Must be run as a user that has 'mqm' access.
 
         """
 
-        self.single_rfh2_message = \
-        open("messages/single_rfh2.dat", "rb").read()
+        self.single_rfh2_message = open(
+            os.path.join(self.messages_dir, "single_rfh2.dat"), "rb").read()
         self.single_rfh2_message_not_well_formed = \
-        self.single_rfh2_message[0:117] + self.single_rfh2_message[121:]
+            self.single_rfh2_message[0:117] + self.single_rfh2_message[121:]
 
-        self.multiple_rfh2_message = \
-        open("messages/multiple_rfh2.dat", "rb").read()
+        self.multiple_rfh2_message = open(
+            os.path.join(self.messages_dir, "multiple_rfh2.dat"), "rb").read()
         self.multiple_rfh2_message_not_well_formed = \
-        self.multiple_rfh2_message[0:117] + self.multiple_rfh2_message[121:]
+            self.multiple_rfh2_message[0:117] + self.multiple_rfh2_message[121:]
 
-        queue_manager = "QM01"
-        channel = "SVRCONN.1"
-        socket = "localhost(31414)"
-        queue_name = "RFH2.TEST"
+        queue_manager = config.MQ.QM.NAME
+        channel = config.MQ.QM.CHANNEL
+        conn_info = "%s(%s)" % (config.MQ.QM.HOST, config.MQ.QM.PORT)
+        queue_name = config.MQ.QUEUE.QUEUE_NAMES['TestRFH2PutGet']
 
         self.qmgr = None
-        try:
-            if pymqi.__mqbuild__ == 'server':
-                self.qmgr = pymqi.QueueManager('QM01')
-            else:
-                self.qmgr = pymqi.QueueManager(None)
-                self.qmgr.connectTCPClient(queue_manager, pymqi.cd(), channel, socket)
-            self.put_queue = pymqi.Queue(self.qmgr, queue_name)
-            self.get_queue = pymqi.Queue(self.qmgr, queue_name)
-            self.clear_queue(self.get_queue)
-        except Exception, e:
-            raise e
+        if pymqi.__mqbuild__ == 'server':
+            self.qmgr = pymqi.QueueManager(queue_manager)
+        else:
+            self.qmgr = pymqi.QueueManager(None)
+            self.qmgr.connect_tcp_client(
+                queue_manager, pymqi.cd(), channel, conn_info, user=None,
+                password=None)
+        self.put_queue = pymqi.Queue(self.qmgr, queue_name)
+        self.get_queue = pymqi.Queue(self.qmgr, queue_name)
+        self.clear_queue(self.get_queue)
 
     def tearDown(self):
         """ Delete queue manager (TESTPMQI).


### PR DESCRIPTION
Add config.py as a central configuration module. This respects the PYMQI_TEST_\* env variable and prefers them to the config defaults.
Use env.py for proper sys.path setting across all test modules so that PYTHONPATH will not be
defeated and all test modules can be run standalone.

Use the config.py information for the test env creation+deletion scripts.

Test fixes:
- Remove unnecessary imports
- Use proper data file paths
- Become independent from changing to the working directory
